### PR TITLE
Fix: Author twitter/github handle type

### DIFF
--- a/app/Filament/Resources/Blog/AuthorResource.php
+++ b/app/Filament/Resources/Blog/AuthorResource.php
@@ -41,11 +41,9 @@ class AuthorResource extends Resource
                                 Forms\Components\MarkdownEditor::make('bio')
                                     ->columnSpan(2),
                                 Forms\Components\TextInput::make('github_handle')
-                                    ->label('GitHub')
-                                    ->url(),
+                                    ->label('GitHub'),
                                 Forms\Components\TextInput::make('twitter_handle')
-                                    ->label('Twitter')
-                                    ->url(),
+                                    ->label('Twitter'),
                             ]),
                     ])
                     ->columnSpan(2),


### PR DESCRIPTION
Both columns are meant for handles but require a URL which causes issues with seeded data when trying to save.