### PR TITLE
Add image columns

### DIFF
--- a/app/Filament/Resources/Blog/PostResource.php
+++ b/app/Filament/Resources/Blog/PostResource.php
@@ -68,6 +68,10 @@ class PostResource extends Resource
                     ]),
                 Forms\Components\Card::make()
                     ->schema([
+                        Forms\Components\FileUpload::make('image')
+                            ->label('Image')
+                            ->image(),
+
                         Forms\Components\Placeholder::make('created_at')
                             ->label('Created at')
                             ->content(fn (?Post $record): string => $record ? $record->created_at->diffForHumans() : '-'),
@@ -87,6 +91,9 @@ class PostResource extends Resource
     {
         return $table
             ->columns([
+                Tables\Columns\ImageColumn::make('image')
+                    ->label('Image'),
+
                 Tables\Columns\TextColumn::make('title')
                     ->searchable()
                     ->sortable(),

--- a/app/Filament/Resources/Shop/ProductResource.php
+++ b/app/Filament/Resources/Shop/ProductResource.php
@@ -213,9 +213,9 @@ class ProductResource extends Resource
     public static function getTableColumns(): array
     {
         return [
-            Tables\Columns\ImageColumn::make('media')
+            Tables\Columns\SpatieMediaLibraryImageColumn::make('product-image')
                 ->label('Image')
-                ->getStateUsing(fn(Product $record) => $record->getFirstMediaUrl('product-images')),
+                ->collection('product-images'),
 
             Tables\Columns\TextColumn::make('name')
                 ->label('Name')

--- a/app/Filament/Resources/Shop/ProductResource.php
+++ b/app/Filament/Resources/Shop/ProductResource.php
@@ -213,6 +213,10 @@ class ProductResource extends Resource
     public static function getTableColumns(): array
     {
         return [
+            Tables\Columns\ImageColumn::make('media')
+                ->label('Image')
+                ->getStateUsing(fn(Product $record) => $record->getFirstMediaUrl('product-images')),
+
             Tables\Columns\TextColumn::make('name')
                 ->label('Name')
                 ->searchable()

--- a/database/factories/Blog/PostFactory.php
+++ b/database/factories/Blog/PostFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories\Blog;
 
 use App\Models\Blog\Post;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
 class PostFactory extends Factory
@@ -19,10 +20,19 @@ class PostFactory extends Factory
             'title' => $title = $this->faker->unique()->sentence(4),
             'slug' => Str::slug($title),
             'content' => $this->faker->realText(),
-            'image' => $this->faker->image(storage_path('app/public'), 100, 100, null, null),
+            'image' => $this->createImage(),
             'published_at' => $this->faker->dateTimeBetween('-6 month', '+1 month'),
             'created_at' => $this->faker->dateTimeBetween('-1 year', '-6 month'),
             'updated_at' => $this->faker->dateTimeBetween('-5 month', 'now'),
         ];
+    }
+
+    public function createImage()
+    {
+        $image = file_get_contents('https://picsum.photos/200');
+        $filename = Str::uuid() . '.jpg';
+
+        Storage::disk('public')->put($filename, $image);
+        return $filename;
     }
 }

--- a/database/factories/Blog/PostFactory.php
+++ b/database/factories/Blog/PostFactory.php
@@ -19,6 +19,7 @@ class PostFactory extends Factory
             'title' => $title = $this->faker->unique()->sentence(4),
             'slug' => Str::slug($title),
             'content' => $this->faker->realText(),
+            'image' => $this->faker->image(storage_path('app/public'), 100, 100, null, null),
             'published_at' => $this->faker->dateTimeBetween('-6 month', '+1 month'),
             'created_at' => $this->faker->dateTimeBetween('-1 year', '-6 month'),
             'updated_at' => $this->faker->dateTimeBetween('-5 month', 'now'),

--- a/database/factories/Shop/ProductFactory.php
+++ b/database/factories/Shop/ProductFactory.php
@@ -39,7 +39,9 @@ class ProductFactory extends Factory
     {
         return $this->afterCreating(function (Product $product) {
             $imageUrl = 'https://picsum.photos/200';
-            $product->addMediaFromUrl($imageUrl)->toMediaCollection('product-images');
+            $product
+                ->addMediaFromUrl($imageUrl)
+                ->toMediaCollection('product-images');
         });
     }
 }

--- a/database/factories/Shop/ProductFactory.php
+++ b/database/factories/Shop/ProductFactory.php
@@ -38,7 +38,7 @@ class ProductFactory extends Factory
     public function configure(): ProductFactory
     {
         return $this->afterCreating(function (Product $product) {
-            $imageUrl = $this->faker->imageUrl(100,100, 'product', true);
+            $imageUrl = 'https://picsum.photos/200';
             $product->addMediaFromUrl($imageUrl)->toMediaCollection('product-images');
         });
     }

--- a/database/factories/Shop/ProductFactory.php
+++ b/database/factories/Shop/ProductFactory.php
@@ -34,4 +34,12 @@ class ProductFactory extends Factory
             'updated_at' => $this->faker->dateTimeBetween('-5 month', 'now'),
         ];
     }
+
+    public function configure(): ProductFactory
+    {
+        return $this->afterCreating(function (Product $product) {
+            $imageUrl = $this->faker->imageUrl(100,100, 'product', true);
+            $product->addMediaFromUrl($imageUrl)->toMediaCollection('product-images');
+        });
+    }
 }

--- a/database/migrations/2021_12_13_073022_create_blog_posts_table.php
+++ b/database/migrations/2021_12_13_073022_create_blog_posts_table.php
@@ -22,6 +22,7 @@ return new class () extends Migration {
             $table->date('published_at')->nullable();
             $table->string('seo_title', 60)->nullable();
             $table->string('seo_description', 160)->nullable();
+            $table->string('image')->nullable();
             $table->timestamps();
         });
     }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -37,7 +37,7 @@ class DatabaseSeeder extends Seeder
 
         Author::factory()->count(20)
             ->has(
-                Post::factory()->count(10)
+                Post::factory()->count(5)
                     ->state(fn (array $attributes, Author $author) => ['blog_category_id' => $blogCategories->random(1)->first()->id]),
                 'posts'
             )

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,11 +15,15 @@ use App\Models\Shop\Product;
 use App\Models\Shop\Review;
 use App\Models\User;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Storage;
 
 class DatabaseSeeder extends Seeder
 {
     public function run(): void
     {
+        // Clear images
+        Storage::deleteDirectory('public');
+
         // Admin
         User::factory()->create([
             'name' => 'Demo User',
@@ -30,6 +34,7 @@ class DatabaseSeeder extends Seeder
         // Blog
         $blogCategories = BlogCategory::factory()->count(20)->create();
         $this->command->info('Blog categories created.');
+
         Author::factory()->count(20)
             ->has(
                 Post::factory()->count(10)
@@ -46,12 +51,16 @@ class DatabaseSeeder extends Seeder
                 'children'
             )->create();
         $this->command->info('Shop categories created.');
+
         $brands = Brand::factory()->count(20)->create();
         $this->command->info('Shop brands created.');
+
         $customers = Customer::factory()->count(1000)->create();
         $this->command->info('Shop customers created.');
+
         Discount::factory()->count(20)->create();
         $this->command->info('Shop discounts created.');
+
         $products = Product::factory()->count(50)
             ->sequence(fn ($sequence) => ['shop_brand_id' => $brands->random(1)->first()->id])
             ->hasAttached($categories->random(rand(3, 6)), ['created_at' => now(), 'updated_at' => now()])
@@ -62,6 +71,7 @@ class DatabaseSeeder extends Seeder
             )
             ->create();
         $this->command->info('Shop products created.');
+
         Order::factory()->count(1000)
             ->sequence(fn ($sequence) => ['shop_customer_id' => $customers->random(1)->first()->id])
             ->has(


### PR DESCRIPTION
Adds image colums for products and posts:

<img width="286" alt="Bildschirmfoto 2022-03-22 um 14 10 44" src="https://user-images.githubusercontent.com/22632550/159489416-6625cc64-c7bc-4a8f-b855-2c3b7ff42d85.png">

Not sure how the demo app is deployed. Probably you need to clear the storage folder on every deploy/reset.