### PR TITLE
Add maintenance note

### DIFF
--- a/resources/views/maintenance.blade.php
+++ b/resources/views/maintenance.blade.php
@@ -1,0 +1,5 @@
+@extends('errors::minimal')
+
+@section('title', __('Be right back'))
+@section('code', '503')
+@section('message', __('Demo is being refreshed.'))

--- a/resources/views/maintenance.blade.php
+++ b/resources/views/maintenance.blade.php
@@ -1,5 +1,5 @@
 @extends('errors::minimal')
 
-@section('title', __('Be right back'))
+@section('title', 'Be right back')
 @section('code', '503')
-@section('message', __('Demo is being refreshed.'))
+@section('message', 'Demo is being refreshed.')


### PR DESCRIPTION
@danharrin A lot of people are confused by the default 503 error when the demo is refreshing. I added a blade file with a better maintenance note for that.

Can you add this to the deployment and merge this PR afterwards?

```bash
# Before
php artisan down --render=maintenance 

# After
php artisan up
```