### PR TITLE
remove duplicate edit action

### DIFF
--- a/app/Filament/Resources/Shop/BrandResource/RelationManagers/ProductsRelationManager.php
+++ b/app/Filament/Resources/Shop/BrandResource/RelationManagers/ProductsRelationManager.php
@@ -26,7 +26,6 @@ class ProductsRelationManager extends RelationManager
                 Tables\Actions\CreateAction::make(),
             ])
             ->actions([
-                Tables\Actions\EditAction::make(),
                 Tables\Actions\DeleteAction::make(),
             ])
             ->groupedBulkActions([

--- a/app/Filament/Resources/Shop/CategoryResource/RelationManagers/ProductsRelationManager.php
+++ b/app/Filament/Resources/Shop/CategoryResource/RelationManagers/ProductsRelationManager.php
@@ -26,7 +26,6 @@ class ProductsRelationManager extends RelationManager
                 Tables\Actions\CreateAction::make(),
             ])
             ->actions([
-                Tables\Actions\EditAction::make(),
                 Tables\Actions\DeleteAction::make(),
             ])
             ->groupedBulkActions([


### PR DESCRIPTION
In this pull request, I have removed the duplicate "edit" action from ProductsRelationManager class for both "Brand" and "Category" resources. Because the table already inherits by the ProductResource, which includes an "edit" button there is a redundant "edit" action.