### PR TITLE
Convert Order 'status' to be Enum

### DIFF
--- a/app/Enums/OrderStatus.php
+++ b/app/Enums/OrderStatus.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasLabel;
+
+enum OrderStatus: string implements HasLabel, HasColor
+{
+    case NEW = 'new';
+
+    case PROCESSING = 'processing';
+
+    case SHIPPED = 'shipped';
+
+    case DELIVERED = 'delivered';
+
+    case CANCELLED = 'cancelled';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::NEW => 'New',
+            self::PROCESSING => 'Processing',
+            self::SHIPPED => 'Shipped',
+            self::DELIVERED => 'Delivered',
+            self::CANCELLED => 'Cancelled',
+        };
+    }
+
+    public function getColor(): string|array|null
+    {
+        return match ($this) {
+            self::NEW => 'gray',
+            self::PROCESSING => 'warning',
+            self::SHIPPED, self::DELIVERED => 'success',
+            self::CANCELLED => 'danger',
+        };
+    }
+}

--- a/app/Enums/OrderStatus.php
+++ b/app/Enums/OrderStatus.php
@@ -7,34 +7,34 @@ use Filament\Support\Contracts\HasLabel;
 
 enum OrderStatus: string implements HasLabel, HasColor
 {
-    case NEW = 'new';
+    case New = 'new';
 
-    case PROCESSING = 'processing';
+    case Processing = 'processing';
 
-    case SHIPPED = 'shipped';
+    case Shipped = 'shipped';
 
-    case DELIVERED = 'delivered';
+    case Delivered = 'delivered';
 
-    case CANCELLED = 'cancelled';
+    case Cancelled = 'cancelled';
 
     public function getLabel(): string
     {
         return match ($this) {
-            self::NEW => 'New',
-            self::PROCESSING => 'Processing',
-            self::SHIPPED => 'Shipped',
-            self::DELIVERED => 'Delivered',
-            self::CANCELLED => 'Cancelled',
+            self::New => 'New',
+            self::Processing => 'Processing',
+            self::Shipped => 'Shipped',
+            self::Delivered => 'Delivered',
+            self::Cancelled => 'Cancelled',
         };
     }
 
     public function getColor(): string|array|null
     {
         return match ($this) {
-            self::NEW => 'gray',
-            self::PROCESSING => 'warning',
-            self::SHIPPED, self::DELIVERED => 'success',
-            self::CANCELLED => 'danger',
+            self::New => 'gray',
+            self::Processing => 'warning',
+            self::Shipped, self::Delivered => 'success',
+            self::Cancelled => 'danger',
         };
     }
 }

--- a/app/Enums/OrderStatus.php
+++ b/app/Enums/OrderStatus.php
@@ -5,7 +5,7 @@ namespace App\Enums;
 use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasLabel;
 
-enum OrderStatus: string implements HasLabel, HasColor
+enum OrderStatus: string implements HasColor, HasLabel
 {
     case NEW = 'new';
 
@@ -28,7 +28,7 @@ enum OrderStatus: string implements HasLabel, HasColor
         };
     }
 
-    public function getColor(): string|array|null
+    public function getColor(): string | array | null
     {
         return match ($this) {
             self::NEW => 'gray',

--- a/app/Filament/Resources/Shop/OrderResource.php
+++ b/app/Filament/Resources/Shop/OrderResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\Shop;
 
+use App\Enums\OrderStatus;
 use App\Filament\Resources\Shop\OrderResource\Pages;
 use App\Filament\Resources\Shop\OrderResource\RelationManagers;
 use App\Filament\Resources\Shop\OrderResource\Widgets\OrderStats;
@@ -76,12 +77,8 @@ class OrderResource extends Resource
                     ->searchable()
                     ->sortable()
                     ->toggleable(),
-                Tables\Columns\BadgeColumn::make('status')
-                    ->colors([
-                        'danger' => 'cancelled',
-                        'warning' => 'processing',
-                        'success' => fn ($state) => in_array($state, ['delivered', 'shipped']),
-                    ]),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge(),
                 Tables\Columns\TextColumn::make('currency')
                     ->getStateUsing(fn ($record): ?string => Currency::find($record->currency)?->name ?? null)
                     ->searchable()
@@ -300,13 +297,7 @@ class OrderResource extends Resource
                 }),
 
             Forms\Components\Select::make('status')
-                ->options([
-                    'new' => 'New',
-                    'processing' => 'Processing',
-                    'shipped' => 'Shipped',
-                    'delivered' => 'Delivered',
-                    'cancelled' => 'Cancelled',
-                ])
+                ->options(OrderStatus::class)
                 ->required()
                 ->native(false),
 

--- a/app/Filament/Widgets/LatestOrders.php
+++ b/app/Filament/Widgets/LatestOrders.php
@@ -32,12 +32,8 @@ class LatestOrders extends BaseWidget
                 Tables\Columns\TextColumn::make('customer.name')
                     ->searchable()
                     ->sortable(),
-                Tables\Columns\BadgeColumn::make('status')
-                    ->colors([
-                        'danger' => 'cancelled',
-                        'warning' => 'processing',
-                        'success' => fn ($state) => in_array($state, ['delivered', 'shipped']),
-                    ]),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge(),
                 Tables\Columns\TextColumn::make('currency')
                     ->getStateUsing(fn ($record): ?string => Currency::find($record->currency)?->name ?? null)
                     ->searchable()

--- a/app/Models/Shop/Order.php
+++ b/app/Models/Shop/Order.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\Shop;
 
+use App\Enums\OrderStatus;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -30,6 +31,10 @@ class Order extends Model
         'shipping_price',
         'shipping_method',
         'notes',
+    ];
+
+    protected $casts = [
+        'status' => OrderStatus::class,
     ];
 
     public function address(): MorphOne


### PR DESCRIPTION
Converted the 'status' field on Order model to be an enum, to provide an example of using Enums in TextColumn and Select with HasLabel and HasColor.