### PR TITLE
fix: add name to package json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "filament-demo",
             "devDependencies": {
                 "@alpinejs/focus": "^3.10.3",
                 "@tailwindcss/forms": "^0.5.3",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+    "name": "filament-demo",
     "private": true,
     "type": "module",
     "scripts": {


### PR DESCRIPTION
Adding "name" to the ```package.json```, to avoid the ```package-lock.json``` "name" value being updated when running ```npm build``` if the repo is cloned a different directory name.

If you clone the demo repo to a directory called "filamentdemo" and run ```npm install```, you should see that the ```package-lock.json``` updates to match your direct name, which is not desirable as it will conflict on further pull or could be committed in error. 