### PR TITLE
Add missing gender field in new customer form

### DIFF
--- a/app/Filament/Resources/Shop/CustomerResource.php
+++ b/app/Filament/Resources/Shop/CustomerResource.php
@@ -49,6 +49,15 @@ class CustomerResource extends Resource
                         Forms\Components\TextInput::make('phone')
                             ->maxLength(255),
 
+                        Forms\Components\Select::make('gender')
+                        ->placeholder('Select gender')
+                        ->options([
+                            'male' => 'Male',
+                            'female' => 'Female',
+                        ])
+                        ->required()
+                        ->native(false),
+
                         Forms\Components\DatePicker::make('birthday')
                             ->maxDate('today'),
                     ])


### PR DESCRIPTION
Customers -> New customer was missing the gender field. Filling this form out resulted in a QueryException:
`Integrity constraint violation: 19 NOT NULL constraint failed: shop_customers.gender`
Fixing this by adding the gender field to this form. This is similar to PR #64 which fixed a similar issue when adding a customer while creating a new order (Orders -> New order -> Adding a customer there)