### PR TITLE
Fix Chrome data breach error on demo login.

### DIFF
--- a/app/Filament/Pages/Auth/Login.php
+++ b/app/Filament/Pages/Auth/Login.php
@@ -12,7 +12,7 @@ class Login extends BasePage
 
         $this->form->fill([
             'email' => 'admin@filamentphp.com',
-            'password' => 'password',
+            'password' => 'wYnatErfIcti',
             'remember' => true,
         ]);
     }

--- a/app/Filament/Pages/Auth/Login.php
+++ b/app/Filament/Pages/Auth/Login.php
@@ -12,7 +12,7 @@ class Login extends BasePage
 
         $this->form->fill([
             'email' => 'admin@filamentphp.com',
-            'password' => 'wYnatErfIcti',
+            'password' => 'demo.Filament@2021!',
             'remember' => true,
         ]);
     }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -24,6 +24,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\Console\Helper\ProgressBar;
 
@@ -41,7 +42,7 @@ class DatabaseSeeder extends Seeder
         $user = $this->withProgressBar(1, fn () => User::factory(1)->create([
             'name' => 'Demo User',
             'email' => 'admin@filamentphp.com',
-            'password' => bcrypt('wYnatErfIcti'),
+            'password' => Hash::make('demo.Filament@2021!'),
         ]));
         $this->command->info('Admin user created.');
 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -41,6 +41,7 @@ class DatabaseSeeder extends Seeder
         $user = $this->withProgressBar(1, fn () => User::factory(1)->create([
             'name' => 'Demo User',
             'email' => 'admin@filamentphp.com',
+            'password' => bcrypt('wYnatErfIcti'),
         ]));
         $this->command->info('Admin user created.');
 


### PR DESCRIPTION
This PR fixes an issue where Chrome shows a “Check your saved passwords” warning when logging into the demo app using the default password. That warning makes the user experienced feel unpolished on Chrome, even though it’s expected behavior.

<img width="1493" alt="SCR-20250322-sunb" src="https://github.com/user-attachments/assets/3924e6e7-3ab4-4712-af10-d0245a731491" />

**Changes:**
1. Replaces the hardcoded "password" in Login.php with a non-breached string (wYnatErfIcti)
2. Updates DatabaseSeeder.php to match with the new password (bcrypt-hashed)

No functionality has changed—this just removes visual friction for demo users.